### PR TITLE
Add persistent mode for trusted channel

### DIFF
--- a/docs/for-users/embedded-node/backup-and-recovery.md
+++ b/docs/for-users/embedded-node/backup-and-recovery.md
@@ -79,9 +79,12 @@ The aezeed key format **should** be compatible with the following wallets: Blixt
 Another option is to use Sparrow Wallet (desktop), but are necessary some preparation steps. This method is also useful in case you want to extract the XPUB for your ZEUS LND node and you want to use it as watch only (deposit-only) in another app. Sparrow will display it in the wallet details.
 
 To import Zeus onchain ypriv / zpriv keys into Sparrow Wallet we have 2 options:
+
 PLEASE DO NOT SHARE THESE KEYS, THESE ARE FULL ACCESS TO YOUR NODE WALLET, KEEP THEM SAFE.
-OPTION A - directly from Zeus UI, go to Backup wallet - and click on the QR on top right corner. It will take few moments to extract the ypriv/zpriv and will display it in full text format and QR code. Now you can import it into Sparrow and have full access to your onchain walellet. In Sparrow keep in mind to switch between segwit and taproot addresses, depending which format you used in Zeus.
-OPTION B - Using Cryptography Toolkit by Guggero (LND dev):
+
+**OPTION A** - directly from Zeus UI, go to Backup wallet - and click on the QR on top right corner. It will take few moments to extract the ypriv/zpriv and will display it in full text format and QR code. Now you can import it into Sparrow and have full access to your onchain walellet. In Sparrow keep in mind to switch between segwit and taproot addresses, depending which format you used in Zeus.
+
+**OPTION B** - Using Cryptography Toolkit by Guggero (LND dev):
 
 - Go to <a href="https://guggero.github.io/cryptography-toolkit/#!/aezeed">Cryptography Toolkit</a> and download the HTML file onto your computer.
 - Open that HTML file in "offline mode" (no internet) and select "aezeed Cipher Seed Scheme" from Tools. Then go to the 2nd tab "Decode Mnemonic".

--- a/docs/for-users/embedded-node/trusted-funding.md
+++ b/docs/for-users/embedded-node/trusted-funding.md
@@ -13,6 +13,8 @@ There are a lot of perks to this set up. You skip on-chain fees, save on routing
 
 ## Steps
 
+Before you begin, be sure you have your Zeus running on "Persistent Mode". That will keep alive the LND service, unintrerrupted in case you switch screens or the phone goes on power saving mode. To activate "Persistent Mode", go to **Settings** - **Embedded Node** - **Advanced** - **Persistent Mode**, switch on the button. It will ask you to restart Zeus. After restart proceed with the next steps.
+
 ### 1 On the remote node, enable zero-conf channels
 
 In your `lnd.conf` add the following lines:

--- a/docs/for-users/embedded-node/trusted-funding.md
+++ b/docs/for-users/embedded-node/trusted-funding.md
@@ -15,7 +15,7 @@ There are a lot of perks to this set up. You skip on-chain fees, save on routing
 
 Before you begin, be sure you have your Zeus running on "Persistent Mode". That will keep alive the LND service, unintrerrupted in case you switch screens or the phone goes on power saving mode. To activate "Persistent Mode", go to **Settings** - **Embedded Node** - **Advanced** - **Persistent Mode**, switch on the button. It will ask you to restart Zeus. After restart proceed with the next steps.
 
-**NOTE: Keep in mind that "Persisternt mode" is available ONLY for Android OS users.**
+**NOTE: Keep in mind that "Persistent mode" is available ONLY for Android OS users.**
 
 ### 1 On the remote node, enable zero-conf channels
 

--- a/docs/for-users/embedded-node/trusted-funding.md
+++ b/docs/for-users/embedded-node/trusted-funding.md
@@ -15,6 +15,8 @@ There are a lot of perks to this set up. You skip on-chain fees, save on routing
 
 Before you begin, be sure you have your Zeus running on "Persistent Mode". That will keep alive the LND service, unintrerrupted in case you switch screens or the phone goes on power saving mode. To activate "Persistent Mode", go to **Settings** - **Embedded Node** - **Advanced** - **Persistent Mode**, switch on the button. It will ask you to restart Zeus. After restart proceed with the next steps.
 
+**NOTE: Keep in mind that "Persisternt mode" is available ONLY for Android OS users.**
+
 ### 1 On the remote node, enable zero-conf channels
 
 In your `lnd.conf` add the following lines:


### PR DESCRIPTION
Added 2 small updates:
- instructions to activate persistent mode for opening a trusted channel with embedded node
- small format text correction in backup instructions.