### PR TITLE
docs: fix broken NWC internal links on intro page

### DIFF
--- a/docs/nostr-wallet-connect/connections.md
+++ b/docs/nostr-wallet-connect/connections.md
@@ -120,8 +120,8 @@ Tap the gear icon on the connections list.
 | --- | --- |
 | **Switch to Cashu wallet** | Routes pay and make-invoice through Cashu instead of Lightning. Only shown if Cashu is enabled. |
 | **Include Lightning Address** | Adds your ZEUS Pay address to new connection URLs. Some Nostr clients use this for your profile. |
-| **Persistent Mode** | Android only — keeps NWC running in the background. See [background](./background). |
-| **Background Audio** | iOS only — ambient track for background relay connections. See [background](./background). |
+| **Persistent Mode** | Android only — keeps NWC running in the background. See [background](/nostr-wallet-connect/background). |
+| **Background Audio** | iOS only — ambient track for background relay connections. See [background](/nostr-wallet-connect/background). |
 | **Learn more** | Opens the full NWC guide at docs.zeusln.app. |
 
 ---

--- a/docs/nostr-wallet-connect/intro.md
+++ b/docs/nostr-wallet-connect/intro.md
@@ -34,7 +34,7 @@ You create named **connections** and share a QR code or a `nostr+walletconnect:/
 
 Cashu is also supported as an optional routing layer. You can enable it in NWC settings to route all NWC payments and invoices through your Cashu wallet instead of Lightning channels.
 
-**Next steps:** [Managing connections →](./connections) · [Keeping it running in the background →](./background)
+**Next steps:** [Managing connections →](/nostr-wallet-connect/connections) · [Keeping it running in the background →](/nostr-wallet-connect/background)
 
 ---
 
@@ -44,7 +44,7 @@ If you have a wallet elsewhere that speaks NWC — Alby Hub is the most common e
 
 Go to `Menu` > `Settings`, tap **Add wallet**, choose **Nostr Wallet Connect**, and paste your `nostr+walletconnect://` connection string. You can also scan a QR code or tap a link to fill it in. After you save, select the wallet and ZEUS will connect to it.
 
-Read more: [Using NWC as your wallet backend →](./client) · [Setting up wallets in ZEUS →](/for-users/using-zeus/wallets)
+Read more: [Using NWC as your wallet backend →](/nostr-wallet-connect/client) · [Setting up wallets in ZEUS →](/for-users/using-zeus/wallets)
 
 ---
 
@@ -83,4 +83,4 @@ Any app that supports [NIP-47](https://nips.nostr.com/47) — Damus, Amethyst, a
 
 **Is NWC safe?**
 
-Each connection has its own secret, permissions, and optional spending cap. You decide what each app can access. See [Managing connections](./connections) for permissions and budgets.
+Each connection has its own secret, permissions, and optional spending cap. You decide what each app can access. See [Managing connections](/nostr-wallet-connect/connections) for permissions and budgets.


### PR DESCRIPTION
## Summary
In this PR, we fix broken internal links in the Nostr Wallet Connect docs. Relative paths like ./connections were resolving under the intro URL (e.g. /nostr-wallet-connect/intro/connections) and returning 404. All cross-links now use absolute doc paths.

- Replace relative ./connections, ./background, and ./client links in intro.md with /nostr-wallet-connect/... paths
- Update background links in the settings table in connections.md to use absolute paths
- Prevents 404s when navigating from the NWC intro page
